### PR TITLE
Shorten post URLs to /slug/ with redirect stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore: [main] # main already covered by deploy.yml
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+      - name: Install Playwright Chromium
+        run: pnpm dlx playwright install --with-deps chromium
+      - run: pnpm test:e2e

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,16 +1,41 @@
 // @ts-check
+import fs from 'node:fs';
+import path from 'node:path';
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import expressiveCode from 'astro-expressive-code';
 import pagefind from 'astro-pagefind';
 import tailwindcss from '@tailwindcss/vite';
+import matter from 'gray-matter';
 import { remarkAlert } from 'remark-github-blockquote-alert';
 import rehypeMermaid from 'rehype-mermaid';
 
-// https://astro.build/config
+const SITE = 'https://urunimi.github.io';
+
+// Compute the set of legacy /:categories/:slug/ URLs so the sitemap excludes
+// them — only the short canonical /slug/ URLs belong in the sitemap. The
+// legacy pages themselves still render a meta-refresh stub with rel=canonical,
+// which is the SEO-correct signal for a static migration.
+const shortSlug = (id) => id.replace(/\.(md|mdx)$/, '').replace(/^\d{4}-\d{2}-\d{2}-/, '');
+const legacyUrls = new Set();
+const postsDir = './src/content/posts';
+for (const f of fs.readdirSync(postsDir)) {
+  if (!/\.(md|mdx)$/.test(f)) continue;
+  const src = fs.readFileSync(path.join(postsDir, f), 'utf8');
+  const { data } = matter(src);
+  const id = f.replace(/\.(md|mdx)$/, '');
+  const short = shortSlug(id);
+  const cats = (data.categories ?? []).map((c) => String(c).toLowerCase());
+  if (cats.length === 0) continue;
+  const legacyPath = [...cats, short].join('/');
+  if (legacyPath !== short) {
+    legacyUrls.add(`${SITE}/${legacyPath}/`);
+  }
+}
+
 export default defineConfig({
-  site: 'https://urunimi.github.io',
+  site: SITE,
   trailingSlash: 'always',
   build: { format: 'directory' },
   markdown: {
@@ -26,7 +51,7 @@ export default defineConfig({
       },
     }),
     mdx(),
-    sitemap(),
+    sitemap({ filter: (page) => !legacyUrls.has(page) }),
     pagefind(),
   ],
   vite: {

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,6 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import { buildPostPath } from '../lib/permalink';
+import { buildPostSlug } from '../lib/permalink';
 
 interface Props { posts: CollectionEntry<'posts'>[]; }
 const { posts } = Astro.props;
@@ -32,7 +32,7 @@ const fmt = (d: Date) => {
           <li class="flex flex-wrap items-baseline gap-3" data-fade>
             <time class="text-ink-muted font-mono text-sm tabular-nums">{fmt(p.data.date)}</time>
             <a
-              href={`/${buildPostPath({ id: p.id, categories: p.data.categories })}/`}
+              href={`/${buildPostSlug(p.id)}/`}
               class="text-ink hover:text-secondary no-underline font-medium"
             >{p.data.title}</a>
             <span class="flex gap-1 flex-wrap">

--- a/src/lib/permalink.test.ts
+++ b/src/lib/permalink.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { buildPostPath } from './permalink';
+import { buildPostPath, buildPostSlug } from './permalink';
+
+describe('buildPostSlug', () => {
+  it('strips YYYY-MM-DD date prefix from content-collection id', () => {
+    expect(buildPostSlug('2023-05-16-solid')).toBe('solid');
+  });
+
+  it('strips .md / .mdx extension too', () => {
+    expect(buildPostSlug('2020-03-31-clean-arch.md')).toBe('clean-arch');
+  });
+
+  it('passes short ids unchanged', () => {
+    expect(buildPostSlug('go-intro')).toBe('go-intro');
+  });
+});
 
 describe('buildPostPath', () => {
   it('strips YYYY-MM-DD date prefix and joins categories', () => {

--- a/src/lib/permalink.ts
+++ b/src/lib/permalink.ts
@@ -1,3 +1,7 @@
+export function buildPostSlug(id: string): string {
+  return id.replace(/\.(md|mdx)$/, '').replace(/^\d{4}-\d{2}-\d{2}-/, '');
+}
+
 export function buildPostPath({
   id,
   categories,
@@ -5,7 +9,7 @@ export function buildPostPath({
   id: string;
   categories: string[];
 }): string {
-  const slug = id.replace(/\.(md|mdx)$/, '').replace(/^\d{4}-\d{2}-\d{2}-/, '');
+  const slug = buildPostSlug(id);
   const cats = categories.map((c) => c.toLowerCase());
   return [...cats, slug].join('/');
 }

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,24 +1,65 @@
 ---
 import { getCollection, render } from 'astro:content';
 import PostLayout from '../layouts/PostLayout.astro';
-import { buildPostPath } from '../lib/permalink';
+import { buildPostPath, buildPostSlug } from '../lib/permalink';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
-  return posts.map((post) => ({
-    params: { slug: buildPostPath({ id: post.id, categories: post.data.categories }) },
-    props: { post },
-  }));
+  const paths: Array<{
+    params: { slug: string };
+    props: { postId: string; canonicalUrl: string; kind: 'canonical' | 'redirect' };
+  }> = [];
+
+  for (const post of posts) {
+    const shortSlug = buildPostSlug(post.id);
+    const legacyPath = buildPostPath({ id: post.id, categories: post.data.categories });
+    const canonicalUrl = `/${shortSlug}/`;
+
+    paths.push({
+      params: { slug: shortSlug },
+      props: { postId: post.id, canonicalUrl, kind: 'canonical' },
+    });
+
+    if (legacyPath !== shortSlug) {
+      paths.push({
+        params: { slug: legacyPath },
+        props: { postId: post.id, canonicalUrl, kind: 'redirect' },
+      });
+    }
+  }
+
+  return paths;
 }
 
-const { post } = Astro.props;
-const { Content, headings } = await render(post);
+const { postId, canonicalUrl, kind } = Astro.props;
+const posts = await getCollection('posts');
+const post = posts.find((p) => p.id === postId)!;
+const absoluteCanonical = new URL(canonicalUrl, Astro.site).toString();
+
+if (kind === 'canonical') {
+  var { Content, headings } = await render(post);
+}
 ---
-<PostLayout
-  title={post.data.title}
-  date={post.data.date}
-  categories={post.data.categories}
-  headings={headings}
->
-  <Content />
-</PostLayout>
+{kind === 'redirect' ? (
+  <html lang="ko">
+    <head>
+      <meta charset="utf-8" />
+      <meta http-equiv="refresh" content={`0; url=${canonicalUrl}`} />
+      <link rel="canonical" href={absoluteCanonical} />
+      <meta name="robots" content="noindex, follow" />
+      <title>{post.data.title}</title>
+    </head>
+    <body>
+      <p>Redirecting to <a href={canonicalUrl}>{canonicalUrl}</a>…</p>
+    </body>
+  </html>
+) : (
+  <PostLayout
+    title={post.data.title}
+    date={post.data.date}
+    categories={post.data.categories}
+    headings={headings!}
+  >
+    <Content />
+  </PostLayout>
+)}

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,6 +1,6 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
-import { buildPostPath } from '../lib/permalink';
+import { buildPostSlug } from '../lib/permalink';
 import type { APIContext } from 'astro';
 
 export const GET = async (context: APIContext) => {
@@ -14,7 +14,7 @@ export const GET = async (context: APIContext) => {
       .map((p) => ({
         title: p.data.title,
         pubDate: p.data.date,
-        link: `/${buildPostPath({ id: p.id, categories: p.data.categories })}/`,
+        link: `/${buildPostSlug(p.id)}/`,
         categories: p.data.categories,
       })),
     customData: '<language>ko-KR</language>',

--- a/tests/e2e/url-preservation.spec.ts
+++ b/tests/e2e/url-preservation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
-import { buildPostPath } from '../../src/lib/permalink';
+import { buildPostPath, buildPostSlug } from '../../src/lib/permalink';
 
 const POSTS_DIR = path.resolve('src/content/posts');
 const postFiles = fs.readdirSync(POSTS_DIR).filter((f) => /\.(md|mdx)$/.test(f));
@@ -11,13 +11,33 @@ for (const f of postFiles) {
   const src = fs.readFileSync(path.join(POSTS_DIR, f), 'utf8');
   const { data } = matter(src);
   const id = f.replace(/\.(md|mdx)$/, '');
-  const url = `/${buildPostPath({ id, categories: data.categories as string[] })}/`;
+  const shortUrl = `/${buildPostSlug(id)}/`;
+  const legacyUrl = `/${buildPostPath({ id, categories: data.categories as string[] })}/`;
 
-  test(`legacy URL loads: ${url}`, async ({ page }) => {
-    const response = await page.goto(url);
+  test(`canonical short URL renders: ${shortUrl}`, async ({ page }) => {
+    const response = await page.goto(shortUrl);
     expect(response?.status()).toBe(200);
     await expect(page.locator('main h1').first()).toBeVisible();
   });
+
+  if (legacyUrl !== shortUrl) {
+    test(`legacy URL serves meta-refresh + canonical to: ${legacyUrl} → ${shortUrl}`, async ({
+      request,
+    }) => {
+      // Assert static redirect stub shape (SEO-correct signal for Google).
+      // Using `request` — we only care about the HTML, not JS navigation timing.
+      const res = await request.get(legacyUrl);
+      expect(res.status()).toBe(200);
+      const html = await res.text();
+      expect(html).toMatch(
+        new RegExp(`<meta http-equiv="refresh" content="0; url=${shortUrl}"`),
+      );
+      expect(html).toMatch(
+        new RegExp(`<link rel="canonical" href="https://urunimi\\.github\\.io${shortUrl}"`),
+      );
+      expect(html).toMatch(/noindex/);
+    });
+  }
 }
 
 test('home loads', async ({ page }) => {
@@ -25,14 +45,19 @@ test('home loads', async ({ page }) => {
   expect(response?.status()).toBe(200);
 });
 
-test('feed.xml loads as RSS', async ({ page }) => {
+test('feed.xml loads and advertises short URLs only', async ({ page }) => {
   const response = await page.goto('/feed.xml');
   expect(response?.status()).toBe(200);
   const body = await response!.text();
   expect(body.startsWith('<?xml')).toBe(true);
+  // Sanity: feed should not mention a multi-segment post path like /:cat/:cat/:slug/
+  expect(body).not.toMatch(/<link>[^<]+\/architecture\/design-pattern\/[^<]+<\/link>/);
 });
 
-test('sitemap loads', async ({ page }) => {
-  const response = await page.goto('/sitemap-index.xml');
+test('sitemap omits legacy URLs', async ({ page }) => {
+  const response = await page.goto('/sitemap-0.xml');
   expect(response?.status()).toBe(200);
+  const body = await response!.text();
+  // No /:cat/:cat/:slug/ triple-segment post paths.
+  expect(body).not.toMatch(/architecture\/design-pattern\/(solid|kiss-yagni)/);
 });


### PR DESCRIPTION
## Summary

Switch canonical post URLs from `/:categories/:slug/` to `/:slug/` while keeping every existing Google-indexed URL working via a static meta-refresh + `rel=canonical` stub.

- `buildPostSlug(id)` → canonical short URL `/solid/`, `/kiss-yagni/`, …
- `src/pages/[...slug].astro` emits **both** paths per post:
  - **canonical short** (`/solid/`) — renders PostLayout
  - **legacy long** (`/architecture/design-pattern/solid/`) — minimal HTML with `<meta http-equiv="refresh" content="0; url=/solid/">`, `<link rel="canonical" href="…/solid/">`, and `<meta name="robots" content="noindex, follow">`. Google's guidance treats this pattern equivalent to a 301 for indexation transfer
- `PostList` and `feed.xml.ts` link to short URLs (new canonical)
- `astro.config.mjs` sitemap `filter` drops legacy paths so Search Console won't see duplicates

## SEO signal chain
- Google crawls existing indexed `/architecture/design-pattern/solid/` → receives 200 with `rel=canonical=/solid/` + `noindex, follow` + meta-refresh → transfers ranking to `/solid/` within a few crawl cycles
- Old external links keep working (no hard 404)

## Test plan
- [x] `pnpm test` — 14/14 unit (permalink + migration scripts)
- [x] `pnpm test:e2e` — **47/47 green** (22 canonical renders + 22 redirect-stub shape + home + feed + sitemap legacy-exclusion)
- [x] `pnpm build` — 72 static pages, sitemap lists 50 (legacy filtered)

## Post-merge
Nothing manual this time — deploy runs automatically on push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)