### PR TITLE
Switch to blog.hovans.com + wire resume link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,7 @@ import matter from 'gray-matter';
 import { remarkAlert } from 'remark-github-blockquote-alert';
 import rehypeMermaid from 'rehype-mermaid';
 
-const SITE = 'https://urunimi.github.io';
+const SITE = 'https://blog.hovans.com';
 
 // Compute the set of legacy /:categories/:slug/ URLs so the sitemap excludes
 // them — only the short canonical /slug/ URLs belong in the sitemap. The

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+blog.hovans.com

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,8 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Prose from '../components/Prose.astro';
 
-// TODO: replace with real resume URL when provided
-const resumeUrl = '#';
+const resumeUrl = 'https://me.hovans.com';
 ---
 <BaseLayout title="About — Ben'space">
   <div class="mx-auto max-w-5xl px-4 py-12">

--- a/tests/e2e/url-preservation.spec.ts
+++ b/tests/e2e/url-preservation.spec.ts
@@ -33,7 +33,7 @@ for (const f of postFiles) {
         new RegExp(`<meta http-equiv="refresh" content="0; url=${shortUrl}"`),
       );
       expect(html).toMatch(
-        new RegExp(`<link rel="canonical" href="https://urunimi\\.github\\.io${shortUrl}"`),
+        new RegExp(`<link rel="canonical" href="https://blog\\.hovans\\.com${shortUrl}"`),
       );
       expect(html).toMatch(/noindex/);
     });


### PR DESCRIPTION
## Summary

- **Canonical domain** → `blog.hovans.com`
  - `astro.config.mjs` `site` updated; sitemap / RSS / legacy-redirect-stub `rel=canonical` all auto-follow
  - `public/CNAME` added — GitHub Pages picks this up to serve the custom domain
  - `urunimi.github.io/*` keeps working via GitHub Pages' automatic 301 to the custom domain (standard behavior when custom domain + HTTPS is enforced), so every previously-indexed URL transfers cleanly
- **Resume link** → `https://me.hovans.com` in About page

## DNS step (manual, after merge)

At the `hovans.com` DNS provider, add:

```
blog.hovans.com    CNAME    urunimi.github.io.
```

Then on GitHub: Settings → Pages → Custom domain should auto-populate from the committed `CNAME` file; tick **Enforce HTTPS** once the Let's Encrypt cert is provisioned (a few minutes to a couple hours).

Verify:
- `curl -sSI https://blog.hovans.com/solid/` → 200
- `curl -sSI https://urunimi.github.io/solid/` → 301 → blog.hovans.com

## SEO follow-up

After DNS is live, submit **Change of Address** in Google Search Console (urunimi.github.io → blog.hovans.com) to accelerate re-crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)